### PR TITLE
Add files via upload

### DIFF
--- a/survey.ons.gov.uk.html
+++ b/survey.ons.gov.uk.html
@@ -1,0 +1,31 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Site closed, redirecting to https://surveys.ons.gov.uk</title>
+  <meta name="author" content="Office for National Statistics">
+  <meta http-equiv="Refresh" content="5;url=https://surveys.ons.gov.uk">
+  <meta name="robots" content="noindex, nofollow">
+  <style>
+    body{
+      font-family: sans-serif;
+      padding: 2rem;
+    }
+    img{
+      width: 220px;
+      height: auto;
+    }
+  </style>
+</head>
+
+<body>
+
+  <img src="https://cdn.ons.gov.uk/sdc/v1.1.0/img/logo.svg" alt="Office for National Statistics" />
+
+  <h1>This website has closed</h1>
+
+  <p>Automatically redirecting to <a href="https://surveys.ons.gov.uk">https://surveys.ons.gov.uk</a></p>
+
+</body>
+</html>


### PR DESCRIPTION
html for the page to be served by requests to https://survey.ons.gov.uk from 4th May 2018 - with a 5 second automatic redirect to its replacement at https://surveys.ons.gov.uk